### PR TITLE
Adapted C++Makefile template

### DIFF
--- a/src/com/dogcows/resources/C++Makefile
+++ b/src/com/dogcows/resources/C++Makefile
@@ -35,7 +35,7 @@ prove: all
 
 
 %$(EXEEXT): %.cc
-	$(LINK.cc) $^ $(LOADLIBES) $(LDLIBS) -o $@
+	$(LINK.cc) $< $(LOADLIBES) $(LDLIBS) -o $@
 
 driver$(EXEEXT): $CLASSNAME$.cc
 


### PR DESCRIPTION
functions outside the class definition (hopefully) do not result in errors anymore
