### PR TITLE
Setting C++11 standard flag to C++Makefile

### DIFF
--- a/src/com/dogcows/resources/C++Makefile
+++ b/src/com/dogcows/resources/C++Makefile
@@ -2,7 +2,7 @@
 # Set the command for your C++ compiler, and specify any compiler flags you
 # want to use (e.g. -g -Werror).
 CXX		= g++
-CXXFLAGS	= -ggdb -Wall
+CXXFLAGS	= -std=c++11 -ggdb -Wall
 
 # The driver outputs TAP (Test Anything Protocol), so it can also be used with
 # any TAP test harness (e.g. prove).  Set the path to your test harness here,


### PR DESCRIPTION
C++11 is accepted by Topcoder arena, therefore our C++ Makefile should use it.
